### PR TITLE
Fix tag casing bug in list_tags fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,7 +149,8 @@ def list_tags():
         for item in knowledge_base:
             for t in item.get('tags', []) or []:
                 if isinstance(t, str):
-                    key = t.strip()
+                    # Normalize case to avoid duplicate tags like 'AI' and 'ai'
+                    key = t.strip().lower()
                     if not key:
                         continue
                     counts[key] = counts.get(key, 0) + 1


### PR DESCRIPTION
## Summary
- normalize tag keys to lowercase in `list_tags` fallback so differently cased tags aren't duplicated

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import app as app_module
from flask import jsonify

# Replace knowledge_base
app_module.knowledge_base = [
    {'tags': ['AI']},
    {'tags': ['ai']},
    {'tags': ['Python']},
]

# Patch get_query_embedding_cached to raise
app_module.get_query_embedding_cached = lambda q: (_ for _ in ()).throw(Exception('fail'))

with app_module.app.test_request_context('/tags?q=foo'):
    resp = app_module.list_tags()
    print(resp.get_json())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a11f7536b88330aaf6823f13d1aec9