### PR TITLE
ci: avoid duplicate build requirements installation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,6 @@ jobs:
         if [ -f build-requirements.txt ]; then
           pip install -r build-requirements.txt
         fi
-        if [ -f build-requirements.txt ]; then
-          pip install -r build-requirements.txt
-        fi
         
     - name: Validate project structure
       run: |


### PR DESCRIPTION
## Summary
- remove redundant build-requirements installation block in validate workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a120ebb5c88330890a79142f668622