### PR TITLE
Enhance mobile UX with navigation bar and swipe gestures

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -24,6 +24,9 @@ class KnowledgeSearch {
         this.sort = 'relevance'; // kept for API compatibility, but no selector now
         this.selectedTags = new Set();
         this.allTags = [];
+        this.navSearch = document.getElementById('navSearch');
+        this.navLibrary = document.getElementById('navLibrary');
+        this.touchStartX = 0;
         
         console.log('KnowledgeSearch constructor - elements found:', {
             searchInput: !!this.searchInput,
@@ -74,12 +77,34 @@ class KnowledgeSearch {
         });
         
         document.addEventListener('click', e => {
-            if (this.panel.classList.contains('active') && 
-                !this.panel.contains(e.target) && 
+            if (this.panel.classList.contains('active') &&
+                !this.panel.contains(e.target) &&
                 !e.target.classList.contains('dot')) {
                 this.hidePanel();
             }
         });
+
+        if (this.navSearch) {
+            this.navSearch.addEventListener('click', () => {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+                this.searchInput.focus();
+            });
+        }
+        if (this.navLibrary) {
+            this.navLibrary.addEventListener('click', () => {
+                const footer = document.querySelector('footer');
+                if (footer) footer.scrollIntoView({ behavior: 'smooth' });
+            });
+        }
+
+        this.panel.addEventListener('touchstart', e => {
+            this.touchStartX = e.changedTouches[0].clientX;
+        }, { passive: true });
+
+        this.panel.addEventListener('touchend', e => {
+            const touchEndX = e.changedTouches[0].clientX;
+            if (touchEndX - this.touchStartX > 50) this.hidePanel();
+        }, { passive: true });
 
         this.searchInput.setAttribute('aria-label', 'Search knowledge');
         

--- a/static/style.css
+++ b/static/style.css
@@ -355,3 +355,34 @@ footer p{margin-bottom:16px;font-size:0.9em}
 .idle-texture{position:fixed;top:0;right:0;width:50vw;height:100vh;background:linear-gradient(135deg,#2a2a2a 0%,#1e1e1e 25%,#2a2a2a 50%,#1a1a1a 75%,#2a2a2a 100%),radial-gradient(circle at 25% 25%,rgba(255,255,255,0.02) 0%,transparent 50%),radial-gradient(circle at 75% 75%,rgba(255,255,255,0.01) 0%,transparent 50%);z-index:999;border-left:1px solid #333;display:flex;align-items:center;justify-content:center;color:#666;font-style:italic;font-size:1.1em;pointer-events:none}
 @media(max-width:768px){.idle-texture{width:100vw}}
 @media(max-width:480px){.container{padding:30px 15px}header{margin-bottom:40px}.search-box{margin-bottom:40px}.dots-grid{max-width:320px;gap:6px}.dot-tooltip{width:200px;font-size:11px}.tooltip-title{font-size:12px}.tooltip-summary{font-size:10px}.panel-body{padding:20px}.panel-header{padding:20px}}
+
+.mobile-nav{display:none}
+
+@media(max-width:768px){
+  body{height:auto;overflow:auto;padding-bottom:60px}
+  footer{padding-bottom:80px}
+  .mobile-nav{
+    display:flex;
+    position:fixed;
+    bottom:0;
+    left:0;
+    width:100%;
+    background:rgba(255,255,255,0.95);
+    backdrop-filter:blur(10px);
+    border-top:1px solid rgba(0,0,0,0.1);
+    z-index:1000;
+    justify-content:space-around;
+  }
+  .mobile-nav .nav-item{
+    flex:1;
+    padding:10px 0;
+    background:none;
+    border:none;
+    font:inherit;
+    color:inherit;
+  }
+  .mobile-nav .nav-item.active{
+    font-weight:600;
+    border-top:2px solid currentColor;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,6 +38,11 @@
         </div>
     </div>
 
+    <nav class="mobile-nav" aria-label="Primary">
+        <button id="navSearch" class="nav-item active">Search</button>
+        <button id="navLibrary" class="nav-item">Library</button>
+    </nav>
+
     <footer>
         <h3>A place for ideas to find each other</h3>
         <p>Search understands meaning, not just words</p>


### PR DESCRIPTION
## Summary
- add fixed bottom navigation for mobile users
- adjust styles for mobile layout and spacing
- support swipe gestures to dismiss the content panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a1222111fc8330a9a4971e7dece516