### PR TITLE
feat: add mobile search endpoints and assets

### DIFF
--- a/static/mobile.css
+++ b/static/mobile.css
@@ -1,0 +1,13 @@
+/* Mobile-specific overrides */
+@media (max-width: 1024px) {
+  .content-panel {
+    width: 100vw;
+  }
+}
+
+button,
+.chip,
+.dot {
+  min-width: 44px;
+  min-height: 44px;
+}

--- a/static/mobile.js
+++ b/static/mobile.js
@@ -1,0 +1,4 @@
+window.KNOWLEDGE_CONFIG = {
+  searchDelay: 400,
+  limit: 15
+};

--- a/static/script.js
+++ b/static/script.js
@@ -19,7 +19,9 @@ class KnowledgeSearch {
 
         // Search state
         this.currentQuery = '';
-        this.limit = 30;
+        const cfg = window.KNOWLEDGE_CONFIG || {};
+        this.searchDelay = cfg.searchDelay || 300;
+        this.limit = cfg.limit || 30;
         this.offset = 0;
         this.sort = 'relevance'; // kept for API compatibility, but no selector now
         this.selectedTags = new Set();
@@ -116,7 +118,7 @@ class KnowledgeSearch {
             // Update tags for this query
             this.updateInlineTags(query).catch(() => {});
             this.performSearch(query, false);
-        }, 300);
+        }, this.searchDelay);
     }
 
     async performSearch(query, append = false) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Knowledge Search</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    {% if is_mobile %}
+    <link rel="stylesheet" href="{{ url_for('static', filename='mobile.css') }}">
+    {% endif %}
 </head>
 <body>
     <div class="container">
@@ -62,6 +65,9 @@
             }(document, "script", "twitter-wjs"));
         }
     </script>
-    <script src="{{ url_for('static', filename='script.js') }}"></script>
+    {% if is_mobile %}
+    <script src="{{ url_for('static', filename='mobile.js') }}" defer></script>
+    {% endif %}
+    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add device-aware template rendering for mobile visitors
- introduce mobile-friendly search, tag, and content endpoints with tighter limits
- add mobile styles and configuration to tune search behavior on touch devices

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a12a3d489883308cd365e14cba86bd